### PR TITLE
chore: do not publish linting settings to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 .github
-.jscsrc
+.eslintrc
 .travis.yml
 /test


### PR DESCRIPTION
Plugin uses eslint, update npmignore accordingly.