### PR TITLE
chore: symantic versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - npm test
         - npm run lint
       after_success:
-        - npm run semantic-release
+        - TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "eslint": "./node_modules/.bin/eslint -c .eslintrc lib test",
     "test-functional": "tap test/**/*test.js -R spec",
     "test": "npm run test-functional",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "files": [
     "lib",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "lodash-cli": "^4.17.4",
     "eslint": "^4.11.0",
-    "semantic-release": "^8.2.0",
+    "semantic-release": "^11.0.1",
     "sync-request": "^3",
     "tap": "^10.7.3"
   }


### PR DESCRIPTION
We are currently getting errors when trying to publish to `npm`.
The two options we tried aren't working
1. `TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release` [travis build](https://travis-ci.org/snyk/snyk-php-plugin/jobs/312371307#L1468). The "Build Leader is found", but it crashes on this: `semantic-release WARN invalid config loglevel="notice"`.
2. `npm run semantic-release`. Here, Travis could not find the build leader. [travis build](https://travis-ci.org/snyk/snyk-php-plugin/jobs/313229602#L925)

The issue of the `invalid config loglevel="notice"` seems to have been fixed [here](https://github.com/semantic-release/semantic-release/pull/480), so by using the latest version, I expect to be able to use the new syntax (`semantic-release` instead of `semantic-release pre && npm publish && semantic-release post`)

If this doesn't work, I guess we'll try removing `php` from the picture and going back to the [old script](https://github.com/snyk/snyk-php-plugin/blob/v1.2.0/.travis.yml).