### PR TITLE
fix: remove v from version to match vulndb versions

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -55,6 +55,8 @@ function buildDependencies(
       depFoundVersion = depFoundVersion || _.get(requires, depName);
     }
 
+    depFoundVersion = depFoundVersion.replace(/^v(\d)/, '$1');
+
     baseObject[depName] = {
       name: depName,
       version: depFoundVersion,

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -72,9 +72,9 @@ tap.test('with alias, uses correct version', function (t) {
         path.resolve(projFolder, 'composer.json')));
       var deps = result.package.dependencies;
       var monologBridgeObj = _.find(deps, {name: 'symfony/monolog-bridge'});
-      // remove v from 'v2.6.0' and the trailing .0
+      // remove the trailing .0
       var actualVersionInstalled =
-        monologBridgeObj.version.substr(1).slice(0, -2);
+        monologBridgeObj.version.slice(0, -2);
       var expectedVersionString = _.get(composerJson,
         'require[\'symfony/monolog-bridge\']'); // '2.6 as 2.7'
       var expectedVersion = expectedVersionString.split(' as ');

--- a/test/stubs/circular_deps_php_project/composer_deps.json
+++ b/test/stubs/circular_deps_php_project/composer_deps.json
@@ -4347,11 +4347,11 @@
           },
           "kevinrob/guzzle-cache-middleware": {
             "name": "kevinrob/guzzle-cache-middleware",
-            "version": "v3.1.0",
+            "version": "3.1.0",
             "from": [
               "circular/deps@4.0-dev",
               "okaufmann/swiss-weather-api@0.0.6",
-              "kevinrob/guzzle-cache-middleware@v3.1.0"
+              "kevinrob/guzzle-cache-middleware@3.1.0"
             ],
             "dependencies": {
               "php": {
@@ -4360,7 +4360,7 @@
                 "from": [
                   "circular/deps@4.0-dev",
                   "okaufmann/swiss-weather-api@0.0.6",
-                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                  "kevinrob/guzzle-cache-middleware@3.1.0",
                   "php@7.1"
                 ],
                 "dependencies": {
@@ -4370,7 +4370,7 @@
                     "from": [
                       "circular/deps@4.0-dev",
                       "okaufmann/swiss-weather-api@0.0.6",
-                      "kevinrob/guzzle-cache-middleware@v3.1.0",
+                      "kevinrob/guzzle-cache-middleware@3.1.0",
                       "php@7.1",
                       "doctrine/inflector@1.3.x-dev"
                     ],
@@ -4381,7 +4381,7 @@
                         "from": [
                           "circular/deps@4.0-dev",
                           "okaufmann/swiss-weather-api@0.0.6",
-                          "kevinrob/guzzle-cache-middleware@v3.1.0",
+                          "kevinrob/guzzle-cache-middleware@3.1.0",
                           "php@7.1",
                           "doctrine/inflector@1.3.x-dev",
                           "doctrine/instantiator@1.2.x-dev"
@@ -4393,7 +4393,7 @@
                             "from": [
                               "circular/deps@4.0-dev",
                               "okaufmann/swiss-weather-api@0.0.6",
-                              "kevinrob/guzzle-cache-middleware@v3.1.0",
+                              "kevinrob/guzzle-cache-middleware@3.1.0",
                               "php@7.1",
                               "doctrine/inflector@1.3.x-dev",
                               "doctrine/instantiator@1.2.x-dev"

--- a/test/stubs/circular_deps_special_test/composer_deps.json
+++ b/test/stubs/circular_deps_special_test/composer_deps.json
@@ -442,13 +442,13 @@
                   },
                   "kevinrob/guzzle-cache-middleware": {
                     "name": "kevinrob/guzzle-cache-middleware",
-                    "version": "v3.1.0",
+                    "version": "3.1.0",
                     "from": [
                       "symfony/console@4.0-dev",
                       "symfony/polyfill-mbstring@1.6-dev",
                       "phar-io/manifest@1.0.x-dev",
                       "okaufmann/swiss-weather-api@0.0.6",
-                      "kevinrob/guzzle-cache-middleware@v3.1.0"
+                      "kevinrob/guzzle-cache-middleware@3.1.0"
                     ],
                     "dependencies": {
                       "php": {
@@ -459,7 +459,7 @@
                           "symfony/polyfill-mbstring@1.6-dev",
                           "phar-io/manifest@1.0.x-dev",
                           "okaufmann/swiss-weather-api@0.0.6",
-                          "kevinrob/guzzle-cache-middleware@v3.1.0",
+                          "kevinrob/guzzle-cache-middleware@3.1.0",
                           "php@7.1.12"
                         ],
                         "dependencies": {}
@@ -1148,7 +1148,7 @@
                           },
                           "kevinrob/guzzle-cache-middleware": {
                             "name": "kevinrob/guzzle-cache-middleware",
-                            "version": "v3.1.0",
+                            "version": "3.1.0",
                             "from": [
                               "symfony/console@4.0-dev",
                               "symfony/polyfill-mbstring@1.6-dev",
@@ -1156,7 +1156,7 @@
                               "doctrine/instantiator@1.2.x-dev",
                               "phar-io/manifest@1.0.x-dev",
                               "okaufmann/swiss-weather-api@0.0.6",
-                              "kevinrob/guzzle-cache-middleware@v3.1.0"
+                              "kevinrob/guzzle-cache-middleware@3.1.0"
                             ],
                             "dependencies": {
                               "php": {
@@ -1169,7 +1169,7 @@
                                   "doctrine/instantiator@1.2.x-dev",
                                   "phar-io/manifest@1.0.x-dev",
                                   "okaufmann/swiss-weather-api@0.0.6",
-                                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                                  "kevinrob/guzzle-cache-middleware@3.1.0",
                                   "php@7.1.12"
                                 ],
                                 "dependencies": {}
@@ -1785,14 +1785,14 @@
                       },
                       "kevinrob/guzzle-cache-middleware": {
                         "name": "kevinrob/guzzle-cache-middleware",
-                        "version": "v3.1.0",
+                        "version": "3.1.0",
                         "from": [
                           "symfony/console@4.0-dev",
                           "symfony/debug@4.0-dev",
                           "doctrine/instantiator@1.2.x-dev",
                           "phar-io/manifest@1.0.x-dev",
                           "okaufmann/swiss-weather-api@0.0.6",
-                          "kevinrob/guzzle-cache-middleware@v3.1.0"
+                          "kevinrob/guzzle-cache-middleware@3.1.0"
                         ],
                         "dependencies": {
                           "php": {
@@ -1804,7 +1804,7 @@
                               "doctrine/instantiator@1.2.x-dev",
                               "phar-io/manifest@1.0.x-dev",
                               "okaufmann/swiss-weather-api@0.0.6",
-                              "kevinrob/guzzle-cache-middleware@v3.1.0",
+                              "kevinrob/guzzle-cache-middleware@3.1.0",
                               "php@7.1.12"
                             ],
                             "dependencies": {}
@@ -2518,13 +2518,13 @@
                   },
                   "kevinrob/guzzle-cache-middleware": {
                     "name": "kevinrob/guzzle-cache-middleware",
-                    "version": "v3.1.0",
+                    "version": "3.1.0",
                     "from": [
                       "symfony/console@4.0-dev",
                       "phpunit/phpunit@6.5.x-dev",
                       "phar-io/manifest@1.0.x-dev",
                       "okaufmann/swiss-weather-api@0.0.6",
-                      "kevinrob/guzzle-cache-middleware@v3.1.0"
+                      "kevinrob/guzzle-cache-middleware@3.1.0"
                     ],
                     "dependencies": {
                       "php": {
@@ -2535,7 +2535,7 @@
                           "phpunit/phpunit@6.5.x-dev",
                           "phar-io/manifest@1.0.x-dev",
                           "okaufmann/swiss-weather-api@0.0.6",
-                          "kevinrob/guzzle-cache-middleware@v3.1.0",
+                          "kevinrob/guzzle-cache-middleware@3.1.0",
                           "php@7.1.12"
                         ],
                         "dependencies": {}
@@ -3336,7 +3336,7 @@
                           },
                           "kevinrob/guzzle-cache-middleware": {
                             "name": "kevinrob/guzzle-cache-middleware",
-                            "version": "v3.1.0",
+                            "version": "3.1.0",
                             "from": [
                               "symfony/console@4.0-dev",
                               "phpunit/phpunit@6.5.x-dev",
@@ -3344,7 +3344,7 @@
                               "doctrine/instantiator@1.2.x-dev",
                               "phar-io/manifest@1.0.x-dev",
                               "okaufmann/swiss-weather-api@0.0.6",
-                              "kevinrob/guzzle-cache-middleware@v3.1.0"
+                              "kevinrob/guzzle-cache-middleware@3.1.0"
                             ],
                             "dependencies": {
                               "php": {
@@ -3357,7 +3357,7 @@
                                   "doctrine/instantiator@1.2.x-dev",
                                   "phar-io/manifest@1.0.x-dev",
                                   "okaufmann/swiss-weather-api@0.0.6",
-                                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                                  "kevinrob/guzzle-cache-middleware@3.1.0",
                                   "php@7.1.12"
                                 ],
                                 "dependencies": {}
@@ -4712,7 +4712,7 @@
                           },
                           "kevinrob/guzzle-cache-middleware": {
                             "name": "kevinrob/guzzle-cache-middleware",
-                            "version": "v3.1.0",
+                            "version": "3.1.0",
                             "from": [
                               "symfony/console@4.0-dev",
                               "phpunit/phpunit@6.5.x-dev",
@@ -4720,7 +4720,7 @@
                               "doctrine/instantiator@1.2.x-dev",
                               "phar-io/manifest@1.0.x-dev",
                               "okaufmann/swiss-weather-api@0.0.6",
-                              "kevinrob/guzzle-cache-middleware@v3.1.0"
+                              "kevinrob/guzzle-cache-middleware@3.1.0"
                             ],
                             "dependencies": {
                               "php": {
@@ -4733,7 +4733,7 @@
                                   "doctrine/instantiator@1.2.x-dev",
                                   "phar-io/manifest@1.0.x-dev",
                                   "okaufmann/swiss-weather-api@0.0.6",
-                                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                                  "kevinrob/guzzle-cache-middleware@3.1.0",
                                   "php@7.1.12"
                                 ],
                                 "dependencies": {}
@@ -5900,11 +5900,11 @@
           },
           "kevinrob/guzzle-cache-middleware": {
             "name": "kevinrob/guzzle-cache-middleware",
-            "version": "v3.1.0",
+            "version": "3.1.0",
             "from": [
               "symfony/console@4.0-dev",
               "okaufmann/swiss-weather-api@0.0.6",
-              "kevinrob/guzzle-cache-middleware@v3.1.0"
+              "kevinrob/guzzle-cache-middleware@3.1.0"
             ],
             "dependencies": {
               "php": {
@@ -5913,7 +5913,7 @@
                 "from": [
                   "symfony/console@4.0-dev",
                   "okaufmann/swiss-weather-api@0.0.6",
-                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                  "kevinrob/guzzle-cache-middleware@3.1.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}

--- a/test/stubs/many_deps_php_project/composer_deps.json
+++ b/test/stubs/many_deps_php_project/composer_deps.json
@@ -1659,11 +1659,11 @@
           },
           "kevinrob/guzzle-cache-middleware": {
             "name": "kevinrob/guzzle-cache-middleware",
-            "version": "v3.1.0",
+            "version": "3.1.0",
             "from": [
               "symfony/console@4.0-dev",
               "okaufmann/swiss-weather-api@0.0.6",
-              "kevinrob/guzzle-cache-middleware@v3.1.0"
+              "kevinrob/guzzle-cache-middleware@3.1.0"
             ],
             "dependencies": {
               "php": {
@@ -1672,7 +1672,7 @@
                 "from": [
                   "symfony/console@4.0-dev",
                   "okaufmann/swiss-weather-api@0.0.6",
-                  "kevinrob/guzzle-cache-middleware@v3.1.0",
+                  "kevinrob/guzzle-cache-middleware@3.1.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}

--- a/test/stubs/proj_with_aliases/composer_deps.json
+++ b/test/stubs/proj_with_aliases/composer_deps.json
@@ -19,10 +19,10 @@
       },
       "symfony/monolog-bundle": {
         "name": "symfony/monolog-bundle",
-        "version": "v3.1.2",
+        "version": "3.1.2",
         "from": [
           "alises/project@0.0.0",
-          "symfony/monolog-bundle@v3.1.2"
+          "symfony/monolog-bundle@3.1.2"
         ],
         "dependencies": {
           "monolog/monolog": {
@@ -30,7 +30,7 @@
             "version": "1.23.0",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
+              "symfony/monolog-bundle@3.1.2",
               "monolog/monolog@1.23.0"
             ],
             "dependencies": {
@@ -39,7 +39,7 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "monolog/monolog@1.23.0",
                   "php@7.1.12"
                 ],
@@ -50,7 +50,7 @@
                 "version": "1.0.2",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "monolog/monolog@1.23.0",
                   "psr/log@1.0.2"
                 ],
@@ -60,7 +60,7 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
+                      "symfony/monolog-bundle@3.1.2",
                       "monolog/monolog@1.23.0",
                       "psr/log@1.0.2",
                       "php@7.1.12"
@@ -76,18 +76,18 @@
             "version": "7.1.12",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
+              "symfony/monolog-bundle@3.1.2",
               "php@7.1.12"
             ],
             "dependencies": {}
           },
           "symfony/config": {
             "name": "symfony/config",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/config@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/config@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -95,20 +95,20 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/config@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/config@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
               },
               "symfony/filesystem": {
                 "name": "symfony/filesystem",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/config@v3.3.13",
-                  "symfony/filesystem@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/config@3.3.13",
+                  "symfony/filesystem@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -116,9 +116,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/config@v3.3.13",
-                      "symfony/filesystem@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/config@3.3.13",
+                      "symfony/filesystem@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -129,11 +129,11 @@
           },
           "symfony/dependency-injection": {
             "name": "symfony/dependency-injection",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/dependency-injection@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/dependency-injection@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -141,8 +141,8 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/dependency-injection@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/dependency-injection@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -152,8 +152,8 @@
                 "version": "1.0.0",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/dependency-injection@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/dependency-injection@3.3.13",
                   "psr/container@1.0.0"
                 ],
                 "dependencies": {
@@ -162,8 +162,8 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/dependency-injection@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/dependency-injection@3.3.13",
                       "psr/container@1.0.0",
                       "php@7.1.12"
                     ],
@@ -175,11 +175,11 @@
           },
           "symfony/http-kernel": {
             "name": "symfony/http-kernel",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/http-kernel@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/http-kernel@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -187,8 +187,8 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -198,8 +198,8 @@
                 "version": "1.0.2",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
                   "psr/log@1.0.2"
                 ],
                 "dependencies": {
@@ -208,8 +208,8 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
                       "psr/log@1.0.2",
                       "php@7.1.12"
                     ],
@@ -219,12 +219,12 @@
               },
               "symfony/debug": {
                 "name": "symfony/debug",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/debug@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/debug@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -232,9 +232,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/debug@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/debug@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -244,9 +244,9 @@
                     "version": "1.0.2",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/debug@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/debug@3.3.13",
                       "psr/log@1.0.2"
                     ],
                     "dependencies": {
@@ -255,9 +255,9 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
-                          "symfony/http-kernel@v3.3.13",
-                          "symfony/debug@v3.3.13",
+                          "symfony/monolog-bundle@3.1.2",
+                          "symfony/http-kernel@3.3.13",
+                          "symfony/debug@3.3.13",
                           "psr/log@1.0.2",
                           "php@7.1.12"
                         ],
@@ -269,12 +269,12 @@
               },
               "symfony/event-dispatcher": {
                 "name": "symfony/event-dispatcher",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/event-dispatcher@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/event-dispatcher@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -282,9 +282,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/event-dispatcher@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/event-dispatcher@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -293,12 +293,12 @@
               },
               "symfony/http-foundation": {
                 "name": "symfony/http-foundation",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/http-foundation@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/http-foundation@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -306,22 +306,22 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/http-foundation@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/http-foundation@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
                   },
                   "symfony/polyfill-mbstring": {
                     "name": "symfony/polyfill-mbstring",
-                    "version": "v1.6.0",
+                    "version": "1.6.0",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/http-foundation@v3.3.13",
-                      "symfony/polyfill-mbstring@v1.6.0"
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/http-foundation@3.3.13",
+                      "symfony/polyfill-mbstring@1.6.0"
                     ],
                     "dependencies": {
                       "php": {
@@ -329,10 +329,10 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
-                          "symfony/http-kernel@v3.3.13",
-                          "symfony/http-foundation@v3.3.13",
-                          "symfony/polyfill-mbstring@v1.6.0",
+                          "symfony/monolog-bundle@3.1.2",
+                          "symfony/http-kernel@3.3.13",
+                          "symfony/http-foundation@3.3.13",
+                          "symfony/polyfill-mbstring@1.6.0",
                           "php@7.1.12"
                         ],
                         "dependencies": {}
@@ -345,11 +345,11 @@
           },
           "symfony/monolog-bridge": {
             "name": "symfony/monolog-bridge",
-            "version": "v2.6.0",
+            "version": "2.6.0",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/monolog-bridge@v2.6.0"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/monolog-bridge@2.6.0"
             ],
             "dependencies": {
               "monolog/monolog": {
@@ -357,8 +357,8 @@
                 "version": "1.23.0",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/monolog-bridge@v2.6.0",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/monolog-bridge@2.6.0",
                   "monolog/monolog@1.23.0"
                 ],
                 "dependencies": {
@@ -367,8 +367,8 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/monolog-bridge@v2.6.0",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/monolog-bridge@2.6.0",
                       "monolog/monolog@1.23.0",
                       "php@7.1.12"
                     ],
@@ -379,8 +379,8 @@
                     "version": "1.0.2",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/monolog-bridge@v2.6.0",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/monolog-bridge@2.6.0",
                       "monolog/monolog@1.23.0",
                       "psr/log@1.0.2"
                     ],
@@ -390,8 +390,8 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
-                          "symfony/monolog-bridge@v2.6.0",
+                          "symfony/monolog-bundle@3.1.2",
+                          "symfony/monolog-bridge@2.6.0",
                           "monolog/monolog@1.23.0",
                           "psr/log@1.0.2",
                           "php@7.1.12"
@@ -407,8 +407,8 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/monolog-bridge@v2.6.0",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/monolog-bridge@2.6.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -419,10 +419,10 @@
       },
       "symfony/monolog-bridge": {
         "name": "symfony/monolog-bridge",
-        "version": "v2.6.0",
+        "version": "2.6.0",
         "from": [
           "alises/project@0.0.0",
-          "symfony/monolog-bridge@v2.6.0"
+          "symfony/monolog-bridge@2.6.0"
         ],
         "dependencies": {
           "monolog/monolog": {
@@ -430,7 +430,7 @@
             "version": "1.23.0",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bridge@v2.6.0",
+              "symfony/monolog-bridge@2.6.0",
               "monolog/monolog@1.23.0"
             ],
             "dependencies": {
@@ -439,7 +439,7 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bridge@v2.6.0",
+                  "symfony/monolog-bridge@2.6.0",
                   "monolog/monolog@1.23.0",
                   "php@7.1.12"
                 ],
@@ -450,7 +450,7 @@
                 "version": "1.0.2",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bridge@v2.6.0",
+                  "symfony/monolog-bridge@2.6.0",
                   "monolog/monolog@1.23.0",
                   "psr/log@1.0.2"
                 ],
@@ -460,7 +460,7 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bridge@v2.6.0",
+                      "symfony/monolog-bridge@2.6.0",
                       "monolog/monolog@1.23.0",
                       "psr/log@1.0.2",
                       "php@7.1.12"
@@ -476,7 +476,7 @@
             "version": "7.1.12",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bridge@v2.6.0",
+              "symfony/monolog-bridge@2.6.0",
               "php@7.1.12"
             ],
             "dependencies": {}

--- a/test/stubs/proj_with_aliases_external_github/composer_deps.json
+++ b/test/stubs/proj_with_aliases_external_github/composer_deps.json
@@ -19,10 +19,10 @@
       },
       "symfony/monolog-bundle": {
         "name": "symfony/monolog-bundle",
-        "version": "v3.1.2",
+        "version": "3.1.2",
         "from": [
           "alises/project@0.0.0",
-          "symfony/monolog-bundle@v3.1.2"
+          "symfony/monolog-bundle@3.1.2"
         ],
         "dependencies": {
           "monolog/monolog": {
@@ -30,7 +30,7 @@
             "version": "1.23.0",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
+              "symfony/monolog-bundle@3.1.2",
               "monolog/monolog@1.23.0"
             ],
             "dependencies": {
@@ -39,7 +39,7 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "monolog/monolog@1.23.0",
                   "php@7.1.12"
                 ],
@@ -50,7 +50,7 @@
                 "version": "1.0.2",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "monolog/monolog@1.23.0",
                   "psr/log@1.0.2"
                 ],
@@ -60,7 +60,7 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
+                      "symfony/monolog-bundle@3.1.2",
                       "monolog/monolog@1.23.0",
                       "psr/log@1.0.2",
                       "php@7.1.12"
@@ -76,18 +76,18 @@
             "version": "7.1.12",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
+              "symfony/monolog-bundle@3.1.2",
               "php@7.1.12"
             ],
             "dependencies": {}
           },
           "symfony/config": {
             "name": "symfony/config",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/config@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/config@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -95,20 +95,20 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/config@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/config@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
               },
               "symfony/filesystem": {
                 "name": "symfony/filesystem",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/config@v3.3.13",
-                  "symfony/filesystem@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/config@3.3.13",
+                  "symfony/filesystem@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -116,9 +116,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/config@v3.3.13",
-                      "symfony/filesystem@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/config@3.3.13",
+                      "symfony/filesystem@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -129,11 +129,11 @@
           },
           "symfony/dependency-injection": {
             "name": "symfony/dependency-injection",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/dependency-injection@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/dependency-injection@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -141,8 +141,8 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/dependency-injection@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/dependency-injection@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -152,8 +152,8 @@
                 "version": "1.0.0",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/dependency-injection@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/dependency-injection@3.3.13",
                   "psr/container@1.0.0"
                 ],
                 "dependencies": {
@@ -162,8 +162,8 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/dependency-injection@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/dependency-injection@3.3.13",
                       "psr/container@1.0.0",
                       "php@7.1.12"
                     ],
@@ -175,11 +175,11 @@
           },
           "symfony/http-kernel": {
             "name": "symfony/http-kernel",
-            "version": "v3.3.13",
+            "version": "3.3.13",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
-              "symfony/http-kernel@v3.3.13"
+              "symfony/monolog-bundle@3.1.2",
+              "symfony/http-kernel@3.3.13"
             ],
             "dependencies": {
               "php": {
@@ -187,8 +187,8 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -198,8 +198,8 @@
                 "version": "1.0.2",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
                   "psr/log@1.0.2"
                 ],
                 "dependencies": {
@@ -208,8 +208,8 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
                       "psr/log@1.0.2",
                       "php@7.1.12"
                     ],
@@ -219,12 +219,12 @@
               },
               "symfony/debug": {
                 "name": "symfony/debug",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/debug@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/debug@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -232,9 +232,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/debug@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/debug@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -244,9 +244,9 @@
                     "version": "1.0.2",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/debug@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/debug@3.3.13",
                       "psr/log@1.0.2"
                     ],
                     "dependencies": {
@@ -255,9 +255,9 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
-                          "symfony/http-kernel@v3.3.13",
-                          "symfony/debug@v3.3.13",
+                          "symfony/monolog-bundle@3.1.2",
+                          "symfony/http-kernel@3.3.13",
+                          "symfony/debug@3.3.13",
                           "psr/log@1.0.2",
                           "php@7.1.12"
                         ],
@@ -269,12 +269,12 @@
               },
               "symfony/event-dispatcher": {
                 "name": "symfony/event-dispatcher",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/event-dispatcher@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/event-dispatcher@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -282,9 +282,9 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/event-dispatcher@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/event-dispatcher@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -293,12 +293,12 @@
               },
               "symfony/http-foundation": {
                 "name": "symfony/http-foundation",
-                "version": "v3.3.13",
+                "version": "3.3.13",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
-                  "symfony/http-kernel@v3.3.13",
-                  "symfony/http-foundation@v3.3.13"
+                  "symfony/monolog-bundle@3.1.2",
+                  "symfony/http-kernel@3.3.13",
+                  "symfony/http-foundation@3.3.13"
                 ],
                 "dependencies": {
                   "php": {
@@ -306,22 +306,22 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/http-foundation@v3.3.13",
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/http-foundation@3.3.13",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
                   },
                   "symfony/polyfill-mbstring": {
                     "name": "symfony/polyfill-mbstring",
-                    "version": "v1.6.0",
+                    "version": "1.6.0",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
-                      "symfony/http-kernel@v3.3.13",
-                      "symfony/http-foundation@v3.3.13",
-                      "symfony/polyfill-mbstring@v1.6.0"
+                      "symfony/monolog-bundle@3.1.2",
+                      "symfony/http-kernel@3.3.13",
+                      "symfony/http-foundation@3.3.13",
+                      "symfony/polyfill-mbstring@1.6.0"
                     ],
                     "dependencies": {
                       "php": {
@@ -329,10 +329,10 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
-                          "symfony/http-kernel@v3.3.13",
-                          "symfony/http-foundation@v3.3.13",
-                          "symfony/polyfill-mbstring@v1.6.0",
+                          "symfony/monolog-bundle@3.1.2",
+                          "symfony/http-kernel@3.3.13",
+                          "symfony/http-foundation@3.3.13",
+                          "symfony/polyfill-mbstring@1.6.0",
                           "php@7.1.12"
                         ],
                         "dependencies": {}
@@ -348,7 +348,7 @@
             "version": "my-bugfix",
             "from": [
               "alises/project@0.0.0",
-              "symfony/monolog-bundle@v3.1.2",
+              "symfony/monolog-bundle@3.1.2",
               "symfony/monolog-bridge@my-bugfix"
             ],
             "dependencies": {
@@ -357,7 +357,7 @@
                 "version": "1.23.0",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "symfony/monolog-bridge@my-bugfix",
                   "monolog/monolog@1.23.0"
                 ],
@@ -367,7 +367,7 @@
                     "version": "7.1.12",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
+                      "symfony/monolog-bundle@3.1.2",
                       "symfony/monolog-bridge@my-bugfix",
                       "monolog/monolog@1.23.0",
                       "php@7.1.12"
@@ -379,7 +379,7 @@
                     "version": "1.0.2",
                     "from": [
                       "alises/project@0.0.0",
-                      "symfony/monolog-bundle@v3.1.2",
+                      "symfony/monolog-bundle@3.1.2",
                       "symfony/monolog-bridge@my-bugfix",
                       "monolog/monolog@1.23.0",
                       "psr/log@1.0.2"
@@ -390,7 +390,7 @@
                         "version": "7.1.12",
                         "from": [
                           "alises/project@0.0.0",
-                          "symfony/monolog-bundle@v3.1.2",
+                          "symfony/monolog-bundle@3.1.2",
                           "symfony/monolog-bridge@my-bugfix",
                           "monolog/monolog@1.23.0",
                           "psr/log@1.0.2",
@@ -407,7 +407,7 @@
                 "version": "7.1.12",
                 "from": [
                   "alises/project@0.0.0",
-                  "symfony/monolog-bundle@v3.1.2",
+                  "symfony/monolog-bundle@3.1.2",
                   "symfony/monolog-bridge@my-bugfix",
                   "php@7.1.12"
                 ],

--- a/test/stubs/vulnerable_project/composer.json
+++ b/test/stubs/vulnerable_project/composer.json
@@ -3,7 +3,7 @@
 	"description" : "A sample vulnerable project",
 	"require" : {
 		"php" : ">=5.3.2",
-		"symfony/symfony": "2.3.1",
+		"symfony/symfony": "v2.3.1",
 		"yiisoft/yii": "1.1.14",
 		"zendframework/zendframework": "2.1.0",
 		"aws/aws-sdk-php": "3.0.0",

--- a/test/stubs/vulnerable_project/composer_deps.json
+++ b/test/stubs/vulnerable_project/composer_deps.json
@@ -19,40 +19,40 @@
       },
       "symfony/symfony": {
         "name": "symfony/symfony",
-        "version": "v2.3.1",
+        "version": "2.3.1",
         "from": [
           "vulnerable/project@0.0.0",
-          "symfony/symfony@v2.3.1"
+          "symfony/symfony@2.3.1"
         ],
         "dependencies": {
           "doctrine/common": {
             "name": "doctrine/common",
-            "version": "v2.5.0",
+            "version": "2.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "doctrine/common@v2.5.0"
+              "symfony/symfony@2.3.1",
+              "doctrine/common@2.5.0"
             ],
             "dependencies": {
               "doctrine/annotations": {
                 "name": "doctrine/annotations",
-                "version": "v1.5.0",
+                "version": "1.5.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0"
                 ],
                 "dependencies": {
                   "doctrine/lexer": {
                     "name": "doctrine/lexer",
-                    "version": "v1.0.1",
+                    "version": "1.0.1",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
-                      "doctrine/lexer@v1.0.1"
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
+                      "doctrine/lexer@1.0.1"
                     ],
                     "dependencies": {
                       "php": {
@@ -60,10 +60,10 @@
                         "version": "7.1.12",
                         "from": [
                           "vulnerable/project@0.0.0",
-                          "symfony/symfony@v2.3.1",
-                          "doctrine/common@v2.5.0",
-                          "doctrine/annotations@v1.5.0",
-                          "doctrine/lexer@v1.0.1",
+                          "symfony/symfony@2.3.1",
+                          "doctrine/common@2.5.0",
+                          "doctrine/annotations@1.5.0",
+                          "doctrine/lexer@1.0.1",
                           "php@7.1.12"
                         ],
                         "dependencies": {}
@@ -75,9 +75,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -86,12 +86,12 @@
               },
               "doctrine/cache": {
                 "name": "doctrine/cache",
-                "version": "v1.7.1",
+                "version": "1.7.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/cache@v1.7.1"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/cache@1.7.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -99,9 +99,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/cache@v1.7.1",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/cache@1.7.1",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -110,12 +110,12 @@
               },
               "doctrine/collections": {
                 "name": "doctrine/collections",
-                "version": "v1.5.0",
+                "version": "1.5.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/collections@v1.5.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/collections@1.5.0"
                 ],
                 "dependencies": {
                   "php": {
@@ -123,9 +123,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/collections@v1.5.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/collections@1.5.0",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -134,12 +134,12 @@
               },
               "doctrine/inflector": {
                 "name": "doctrine/inflector",
-                "version": "v1.2.0",
+                "version": "1.2.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/inflector@v1.2.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/inflector@1.2.0"
                 ],
                 "dependencies": {
                   "php": {
@@ -147,9 +147,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/inflector@v1.2.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/inflector@1.2.0",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -158,12 +158,12 @@
               },
               "doctrine/lexer": {
                 "name": "doctrine/lexer",
-                "version": "v1.0.1",
+                "version": "1.0.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/lexer@v1.0.1"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/lexer@1.0.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -171,9 +171,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/lexer@v1.0.1",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/lexer@1.0.1",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -185,8 +185,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -198,7 +198,7 @@
             "version": "7.1.12",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
+              "symfony/symfony@2.3.1",
               "php@7.1.12"
             ],
             "dependencies": {}
@@ -208,7 +208,7 @@
             "version": "1.0.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
+              "symfony/symfony@2.3.1",
               "psr/log@1.0.2"
             ],
             "dependencies": {
@@ -217,7 +217,7 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
+                  "symfony/symfony@2.3.1",
                   "psr/log@1.0.2",
                   "php@7.1.12"
                 ],
@@ -227,11 +227,11 @@
           },
           "symfony/icu": {
             "name": "symfony/icu",
-            "version": "v1.2.2",
+            "version": "1.2.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "symfony/icu@v1.2.2"
+              "symfony/symfony@2.3.1",
+              "symfony/icu@1.2.2"
             ],
             "dependencies": {
               "ext-intl": {
@@ -239,8 +239,8 @@
                 "version": "1.1.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "ext-intl@1.1.0"
                 ],
                 "dependencies": {}
@@ -250,8 +250,8 @@
                 "version": ">=4.4",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "lib-icu@>=4.4"
                 ],
                 "dependencies": {}
@@ -261,8 +261,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -272,8 +272,8 @@
                 "version": "~2.3",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "symfony/intl@~2.3"
                 ],
                 "dependencies": {}
@@ -282,11 +282,11 @@
           },
           "twig/twig": {
             "name": "twig/twig",
-            "version": "v1.35.0",
+            "version": "1.35.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "twig/twig@v1.35.0"
+              "symfony/symfony@2.3.1",
+              "twig/twig@1.35.0"
             ],
             "dependencies": {
               "php": {
@@ -294,8 +294,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "twig/twig@v1.35.0",
+                  "symfony/symfony@2.3.1",
+                  "twig/twig@1.35.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -363,12 +363,12 @@
             "dependencies": {
               "guzzlehttp/promises": {
                 "name": "guzzlehttp/promises",
-                "version": "v1.3.1",
+                "version": "1.3.1",
                 "from": [
                   "vulnerable/project@0.0.0",
                   "aws/aws-sdk-php@3.0.0",
                   "guzzlehttp/guzzle@6.3.0",
-                  "guzzlehttp/promises@v1.3.1"
+                  "guzzlehttp/promises@1.3.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -378,7 +378,7 @@
                       "vulnerable/project@0.0.0",
                       "aws/aws-sdk-php@3.0.0",
                       "guzzlehttp/guzzle@6.3.0",
-                      "guzzlehttp/promises@v1.3.1",
+                      "guzzlehttp/promises@1.3.1",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -450,11 +450,11 @@
           },
           "guzzlehttp/promises": {
             "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
+            "version": "1.3.1",
             "from": [
               "vulnerable/project@0.0.0",
               "aws/aws-sdk-php@3.0.0",
-              "guzzlehttp/promises@v1.3.1"
+              "guzzlehttp/promises@1.3.1"
             ],
             "dependencies": {
               "php": {
@@ -463,7 +463,7 @@
                 "from": [
                   "vulnerable/project@0.0.0",
                   "aws/aws-sdk-php@3.0.0",
-                  "guzzlehttp/promises@v1.3.1",
+                  "guzzlehttp/promises@1.3.1",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -552,29 +552,29 @@
       },
       "doctrine/common": {
         "name": "doctrine/common",
-        "version": "v2.5.0",
+        "version": "2.5.0",
         "from": [
           "vulnerable/project@0.0.0",
-          "doctrine/common@v2.5.0"
+          "doctrine/common@2.5.0"
         ],
         "dependencies": {
           "doctrine/annotations": {
             "name": "doctrine/annotations",
-            "version": "v1.5.0",
+            "version": "1.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/annotations@v1.5.0"
+              "doctrine/common@2.5.0",
+              "doctrine/annotations@1.5.0"
             ],
             "dependencies": {
               "doctrine/lexer": {
                 "name": "doctrine/lexer",
-                "version": "v1.0.1",
+                "version": "1.0.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0",
-                  "doctrine/lexer@v1.0.1"
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0",
+                  "doctrine/lexer@1.0.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -582,9 +582,9 @@
                     "version": "7.1.12",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
-                      "doctrine/lexer@v1.0.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
+                      "doctrine/lexer@1.0.1",
                       "php@7.1.12"
                     ],
                     "dependencies": {}
@@ -596,8 +596,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -606,11 +606,11 @@
           },
           "doctrine/cache": {
             "name": "doctrine/cache",
-            "version": "v1.7.1",
+            "version": "1.7.1",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/cache@v1.7.1"
+              "doctrine/common@2.5.0",
+              "doctrine/cache@1.7.1"
             ],
             "dependencies": {
               "php": {
@@ -618,8 +618,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/cache@v1.7.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/cache@1.7.1",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -628,11 +628,11 @@
           },
           "doctrine/collections": {
             "name": "doctrine/collections",
-            "version": "v1.5.0",
+            "version": "1.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/collections@v1.5.0"
+              "doctrine/common@2.5.0",
+              "doctrine/collections@1.5.0"
             ],
             "dependencies": {
               "php": {
@@ -640,8 +640,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/collections@v1.5.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/collections@1.5.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -650,11 +650,11 @@
           },
           "doctrine/inflector": {
             "name": "doctrine/inflector",
-            "version": "v1.2.0",
+            "version": "1.2.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/inflector@v1.2.0"
+              "doctrine/common@2.5.0",
+              "doctrine/inflector@1.2.0"
             ],
             "dependencies": {
               "php": {
@@ -662,8 +662,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/inflector@v1.2.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/inflector@1.2.0",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -672,11 +672,11 @@
           },
           "doctrine/lexer": {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.0.1",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/lexer@v1.0.1"
+              "doctrine/common@2.5.0",
+              "doctrine/lexer@1.0.1"
             ],
             "dependencies": {
               "php": {
@@ -684,8 +684,8 @@
                 "version": "7.1.12",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/lexer@v1.0.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/lexer@1.0.1",
                   "php@7.1.12"
                 ],
                 "dependencies": {}
@@ -697,7 +697,7 @@
             "version": "7.1.12",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
+              "doctrine/common@2.5.0",
               "php@7.1.12"
             ],
             "dependencies": {}

--- a/test/stubs/vulnerable_project/composer_deps_no_system_versions.json
+++ b/test/stubs/vulnerable_project/composer_deps_no_system_versions.json
@@ -19,40 +19,40 @@
       },
       "symfony/symfony": {
         "name": "symfony/symfony",
-        "version": "v2.3.1",
+        "version": "2.3.1",
         "from": [
           "vulnerable/project@0.0.0",
-          "symfony/symfony@v2.3.1"
+          "symfony/symfony@2.3.1"
         ],
         "dependencies": {
           "doctrine/common": {
             "name": "doctrine/common",
-            "version": "v2.5.0",
+            "version": "2.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "doctrine/common@v2.5.0"
+              "symfony/symfony@2.3.1",
+              "doctrine/common@2.5.0"
             ],
             "dependencies": {
               "doctrine/annotations": {
                 "name": "doctrine/annotations",
-                "version": "v1.5.0",
+                "version": "1.5.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0"
                 ],
                 "dependencies": {
                   "doctrine/lexer": {
                     "name": "doctrine/lexer",
-                    "version": "v1.0.1",
+                    "version": "1.0.1",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
-                      "doctrine/lexer@v1.0.1"
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
+                      "doctrine/lexer@1.0.1"
                     ],
                     "dependencies": {
                       "php": {
@@ -60,10 +60,10 @@
                         "version": ">=5.3.2",
                         "from": [
                           "vulnerable/project@0.0.0",
-                          "symfony/symfony@v2.3.1",
-                          "doctrine/common@v2.5.0",
-                          "doctrine/annotations@v1.5.0",
-                          "doctrine/lexer@v1.0.1",
+                          "symfony/symfony@2.3.1",
+                          "doctrine/common@2.5.0",
+                          "doctrine/annotations@1.5.0",
+                          "doctrine/lexer@1.0.1",
                           "php@>=5.3.2"
                         ],
                         "dependencies": {}
@@ -75,9 +75,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -86,12 +86,12 @@
               },
               "doctrine/cache": {
                 "name": "doctrine/cache",
-                "version": "v1.7.1",
+                "version": "1.7.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/cache@v1.7.1"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/cache@1.7.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -99,9 +99,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/cache@v1.7.1",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/cache@1.7.1",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -110,12 +110,12 @@
               },
               "doctrine/collections": {
                 "name": "doctrine/collections",
-                "version": "v1.5.0",
+                "version": "1.5.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/collections@v1.5.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/collections@1.5.0"
                 ],
                 "dependencies": {
                   "php": {
@@ -123,9 +123,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/collections@v1.5.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/collections@1.5.0",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -134,12 +134,12 @@
               },
               "doctrine/inflector": {
                 "name": "doctrine/inflector",
-                "version": "v1.2.0",
+                "version": "1.2.0",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/inflector@v1.2.0"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/inflector@1.2.0"
                 ],
                 "dependencies": {
                   "php": {
@@ -147,9 +147,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/inflector@v1.2.0",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/inflector@1.2.0",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -158,12 +158,12 @@
               },
               "doctrine/lexer": {
                 "name": "doctrine/lexer",
-                "version": "v1.0.1",
+                "version": "1.0.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/lexer@v1.0.1"
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/lexer@1.0.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -171,9 +171,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "symfony/symfony@v2.3.1",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/lexer@v1.0.1",
+                      "symfony/symfony@2.3.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/lexer@1.0.1",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -185,8 +185,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "doctrine/common@v2.5.0",
+                  "symfony/symfony@2.3.1",
+                  "doctrine/common@2.5.0",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -198,7 +198,7 @@
             "version": ">=5.3.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
+              "symfony/symfony@2.3.1",
               "php@>=5.3.2"
             ],
             "dependencies": {}
@@ -208,7 +208,7 @@
             "version": "1.0.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
+              "symfony/symfony@2.3.1",
               "psr/log@1.0.2"
             ],
             "dependencies": {
@@ -217,7 +217,7 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
+                  "symfony/symfony@2.3.1",
                   "psr/log@1.0.2",
                   "php@>=5.3.2"
                 ],
@@ -227,11 +227,11 @@
           },
           "symfony/icu": {
             "name": "symfony/icu",
-            "version": "v1.2.2",
+            "version": "1.2.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "symfony/icu@v1.2.2"
+              "symfony/symfony@2.3.1",
+              "symfony/icu@1.2.2"
             ],
             "dependencies": {
               "ext-intl": {
@@ -239,8 +239,8 @@
                 "version": "*",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "ext-intl@*"
                 ],
                 "dependencies": {}
@@ -250,8 +250,8 @@
                 "version": ">=4.4",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "lib-icu@>=4.4"
                 ],
                 "dependencies": {}
@@ -261,8 +261,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -272,8 +272,8 @@
                 "version": "~2.3",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "symfony/icu@v1.2.2",
+                  "symfony/symfony@2.3.1",
+                  "symfony/icu@1.2.2",
                   "symfony/intl@~2.3"
                 ],
                 "dependencies": {}
@@ -282,11 +282,11 @@
           },
           "twig/twig": {
             "name": "twig/twig",
-            "version": "v1.35.0",
+            "version": "1.35.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "symfony/symfony@v2.3.1",
-              "twig/twig@v1.35.0"
+              "symfony/symfony@2.3.1",
+              "twig/twig@1.35.0"
             ],
             "dependencies": {
               "php": {
@@ -294,8 +294,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "symfony/symfony@v2.3.1",
-                  "twig/twig@v1.35.0",
+                  "symfony/symfony@2.3.1",
+                  "twig/twig@1.35.0",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -363,12 +363,12 @@
             "dependencies": {
               "guzzlehttp/promises": {
                 "name": "guzzlehttp/promises",
-                "version": "v1.3.1",
+                "version": "1.3.1",
                 "from": [
                   "vulnerable/project@0.0.0",
                   "aws/aws-sdk-php@3.0.0",
                   "guzzlehttp/guzzle@6.3.0",
-                  "guzzlehttp/promises@v1.3.1"
+                  "guzzlehttp/promises@1.3.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -378,7 +378,7 @@
                       "vulnerable/project@0.0.0",
                       "aws/aws-sdk-php@3.0.0",
                       "guzzlehttp/guzzle@6.3.0",
-                      "guzzlehttp/promises@v1.3.1",
+                      "guzzlehttp/promises@1.3.1",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -450,11 +450,11 @@
           },
           "guzzlehttp/promises": {
             "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
+            "version": "1.3.1",
             "from": [
               "vulnerable/project@0.0.0",
               "aws/aws-sdk-php@3.0.0",
-              "guzzlehttp/promises@v1.3.1"
+              "guzzlehttp/promises@1.3.1"
             ],
             "dependencies": {
               "php": {
@@ -463,7 +463,7 @@
                 "from": [
                   "vulnerable/project@0.0.0",
                   "aws/aws-sdk-php@3.0.0",
-                  "guzzlehttp/promises@v1.3.1",
+                  "guzzlehttp/promises@1.3.1",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -552,29 +552,29 @@
       },
       "doctrine/common": {
         "name": "doctrine/common",
-        "version": "v2.5.0",
+        "version": "2.5.0",
         "from": [
           "vulnerable/project@0.0.0",
-          "doctrine/common@v2.5.0"
+          "doctrine/common@2.5.0"
         ],
         "dependencies": {
           "doctrine/annotations": {
             "name": "doctrine/annotations",
-            "version": "v1.5.0",
+            "version": "1.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/annotations@v1.5.0"
+              "doctrine/common@2.5.0",
+              "doctrine/annotations@1.5.0"
             ],
             "dependencies": {
               "doctrine/lexer": {
                 "name": "doctrine/lexer",
-                "version": "v1.0.1",
+                "version": "1.0.1",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0",
-                  "doctrine/lexer@v1.0.1"
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0",
+                  "doctrine/lexer@1.0.1"
                 ],
                 "dependencies": {
                   "php": {
@@ -582,9 +582,9 @@
                     "version": ">=5.3.2",
                     "from": [
                       "vulnerable/project@0.0.0",
-                      "doctrine/common@v2.5.0",
-                      "doctrine/annotations@v1.5.0",
-                      "doctrine/lexer@v1.0.1",
+                      "doctrine/common@2.5.0",
+                      "doctrine/annotations@1.5.0",
+                      "doctrine/lexer@1.0.1",
                       "php@>=5.3.2"
                     ],
                     "dependencies": {}
@@ -596,8 +596,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/annotations@v1.5.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/annotations@1.5.0",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -606,11 +606,11 @@
           },
           "doctrine/cache": {
             "name": "doctrine/cache",
-            "version": "v1.7.1",
+            "version": "1.7.1",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/cache@v1.7.1"
+              "doctrine/common@2.5.0",
+              "doctrine/cache@1.7.1"
             ],
             "dependencies": {
               "php": {
@@ -618,8 +618,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/cache@v1.7.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/cache@1.7.1",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -628,11 +628,11 @@
           },
           "doctrine/collections": {
             "name": "doctrine/collections",
-            "version": "v1.5.0",
+            "version": "1.5.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/collections@v1.5.0"
+              "doctrine/common@2.5.0",
+              "doctrine/collections@1.5.0"
             ],
             "dependencies": {
               "php": {
@@ -640,8 +640,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/collections@v1.5.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/collections@1.5.0",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -650,11 +650,11 @@
           },
           "doctrine/inflector": {
             "name": "doctrine/inflector",
-            "version": "v1.2.0",
+            "version": "1.2.0",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/inflector@v1.2.0"
+              "doctrine/common@2.5.0",
+              "doctrine/inflector@1.2.0"
             ],
             "dependencies": {
               "php": {
@@ -662,8 +662,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/inflector@v1.2.0",
+                  "doctrine/common@2.5.0",
+                  "doctrine/inflector@1.2.0",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -672,11 +672,11 @@
           },
           "doctrine/lexer": {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.0.1",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
-              "doctrine/lexer@v1.0.1"
+              "doctrine/common@2.5.0",
+              "doctrine/lexer@1.0.1"
             ],
             "dependencies": {
               "php": {
@@ -684,8 +684,8 @@
                 "version": ">=5.3.2",
                 "from": [
                   "vulnerable/project@0.0.0",
-                  "doctrine/common@v2.5.0",
-                  "doctrine/lexer@v1.0.1",
+                  "doctrine/common@2.5.0",
+                  "doctrine/lexer@1.0.1",
                   "php@>=5.3.2"
                 ],
                 "dependencies": {}
@@ -697,7 +697,7 @@
             "version": ">=5.3.2",
             "from": [
               "vulnerable/project@0.0.0",
-              "doctrine/common@v2.5.0",
+              "doctrine/common@2.5.0",
               "php@>=5.3.2"
             ],
             "dependencies": {}


### PR DESCRIPTION
We store the versions in our vuln db without v prefix (e.g: v2.3.4 will be stored as 2.3.4) this PR removes the prefix from the version in the dep list it generates so that it will match our versions.  