### PR TITLE
chore: remove TRAVIS_JOB_NUMBER=WORKAROUND.1 hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       script:
         - npm run lint
       after_success:
-        - TRAVIS_JOB_NUMBER=WORKAROUND.1 npm run semantic-release
+        - npm run semantic-release
 branches:
   only:
     - master


### PR DESCRIPTION
Hopefully this will help with
```
semantic-release WARN invalid config loglevel="notice"
[Travis Deploy Once]: Elect build leader among builds with Node versions: 8, 6, 4, 0.12, 8.
[Travis Deploy Once]: Elect job 5 as build leader as it runs the highest node version (8).
[Travis Deploy Once]: The current job (WORKAROUND.1) is not the build leader.
semantic-release ERR! pre This test run is not the build leader and therefore a new version won’t be published.
```

🙈 