### PR TITLE
feat: lodash as a full dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
 cache:
   directories:
     - node_modules
-before_script:
-  - "npm run build"
 script:
   - "npm test"
 jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ cache:
 
 environment:
   matrix:
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
@@ -30,7 +29,6 @@ install:
   - node --version
   - npm --version
   - npm install
-  - npm run build
 
 test_script:
   - npm run test

--- a/lib/composer.js
+++ b/lib/composer.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var _ = require('../dist/lodash-min');
+var _ = require('lodash');
 
 function loadJsonFile(basePath, fileName) {
   var resolvedPath = path.join(basePath, fileName);

--- a/lib/system_deps.js
+++ b/lib/system_deps.js
@@ -1,4 +1,4 @@
-var _ = require('../dist/lodash-min');
+var _ = require('lodash');
 var cmds = require('./composer_cmds.js');
 
 function isSet(variable) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Snyk CLI PHP plugin",
   "main": "lib/index.js",
   "scripts": {
-    "build": "./node_modules/.bin/lodash -p -o ./dist/lodash-min.js include=get,find,clone,invert,forEach,findKey",
     "lint": "npm run eslint",
     "eslint": "./node_modules/.bin/eslint -c .eslintrc lib test",
     "test-functional": "tap test/**/*test.js -R spec",
@@ -11,8 +10,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "files": [
-    "lib",
-    "dist"
+    "lib"
   ],
   "homepage": "https://github.com/snyk/snyk-php-plugin",
   "repository": {
@@ -22,10 +20,10 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "debug": "^3.1.0"
+    "debug": "^3.1.0",
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "lodash-cli": "^4.17.4",
     "eslint": "^4.11.0",
     "semantic-release": "^8.2.0",
     "sync-request": "^3",

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,7 +1,7 @@
 var tap = require('tap');
 var path = require('path');
 var fs = require('fs');
-var _ = require('../dist/lodash-min');
+var _ = require('lodash');
 var request = require('sync-request');
 var systemVersionsStub = require(
   './stubs/system_deps_stub.js').systemDepsStub;


### PR DESCRIPTION
Aligning with our CLI use of `lodash` in snyk/snyk-internal#366, making use of a full `lodash` dependency in this plugin as well. The idea is to to fuss over the specific sub-parts as a minified package, and allow the CLI and the plugins to share the same dep. `^` is important here.