### PR TITLE
Fixes filename handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function inspect(basePath, fileName, options) {
     }
     // we want to load the json file as well; usually composer.json
     composerJsonObj = loadJsonFile(basePath,
-      fileName.split('.').shift() + '.json');
+      fileName.split('.').slice(0, -1).join('.') + '.json');
     // load system versions of dependencies if available
     systemVersions = systemDeps(basePath, options);
   } catch (error) {


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes filename parsing handling
`./foo/bar/composer.lock` and
`foo/bar/composer.lock` should both be handled the same. So i replaced the string spliting and instead of taking the first array element, i remove the last one

#### Where should the reviewer start?

#### How should this be manually tested?
```shell
mkdir snyk.test
composer --working-dir=./snyk.test/ require psr/cache
snyk test --file=./snyk.test/composer.lock
```
The dot in the path is important 

#### Any background context you want to provide?
n/a

#### What are the relevant tickets?
snyk/snyk#256

#### Screenshots
n/a

#### Additional questions
n/a