### PR TITLE
fix: use correct folder for publishing into npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "unit-test": "tap -Rspec test/*.test.ts --timeout=300"
   },
   "files": [
-    "lib"
+    "dist"
   ],
   "homepage": "https://github.com/snyk/snyk-php-plugin",
   "repository": {


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Use `dist` folder to publish instead of `lib` (leftover bug from moving from JS to TS)