### PR TITLE
fix: move tslib to part of the production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@snyk/composer-lockfile-parser": "1.0.3"
+    "@snyk/composer-lockfile-parser": "1.0.3",
+    "tslib": "1.9.3"
   },
   "devDependencies": {
     "@types/node": "6.14.6",
@@ -34,7 +35,6 @@
     "eslint": "5.16.0",
     "sync-request": "3.0.1",
     "tap": "12.7.0",
-    "tslib": "1.9.3",
     "typescript": "3.5.1"
   }
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
move `tslib` to part of the production dependencies
helps to solve https://github.com/snyk/snyk/issues/667
