### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.2.0",
     "@snyk/composer-lockfile-parser": "1.2.0",
-    "tslib": "1.9.3"
+    "tslib": "1.10.0"
   },
   "devDependencies": {
     "@types/node": "6.14.6",
@@ -36,6 +36,6 @@
     "eslint": "5.16.0",
     "sync-request": "3.0.1",
     "tap": "12.7.0",
-    "typescript": "3.5.1"
+    "typescript": "3.7.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
-        "lib": ["es5", "es2015.promise"],
+        "target": "es2015",
+        "lib": ["es2015"],
         "module": "commonjs",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
