### PR TITLE
Add license and remove "production" env var from release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    environment:
-      NODE_ENV: "production"
     resource_class: small
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "unit-test": "tap -Rspec test/*.test.ts --timeout=300"
   },
   "files": [
-    "dist"
+    "dist",
+    "LICENSE"
   ],
   "homepage": "https://github.com/snyk/snyk-php-plugin",
   "repository": {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- add LICENSE to the `files` in package.json to include it with the npmjs release
- remove the `production` env var from the release job in CCI so that typescript (a dev dependency) will be available for when running `npx semantic-release`

#### Any background context you want to provide?
Failing CI: https://app.circleci.com/pipelines/github/snyk/snyk-php-plugin/11/workflows/e635ac4b-038c-4554-ac41-26c06b3681ee/jobs/47
