### PR TITLE
fix: [OSM-2746] Fixed bundle generation by splitting out the eslint-specific tsconfig

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default tseslint.config({
     languageOptions: {
         parserOptions: {
             parser: '@typescript-eslint/parser',
-            project: "./tsconfig.json"
+            project: "./tsconfig.eslint.json"
         },
     },
     plugins: {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "/dev/null",
+  },
+  "include": [
+    "./lib/**/*",
+    "./test/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,23 +2,15 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es2015",
-        "lib": ["es2015"],
+        "target": "es2019",
+        "lib": ["es2019"],
         "module": "commonjs",
+        "allowJs": false,
         "sourceMap": true,
         "declaration": true,
         "importHelpers": true,
         "strict": true,
         "noImplicitAny": false
     },
-    "include": [
-        "lib",
-        "test"
-    ],
-    "files": [
-        "node_modules/typescript/lib/lib.es6.d.ts"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+    "include": ["./lib/**/*"]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Include only `lib` when building the project under `/dist`.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
In the previous PR I added "test" to `tsconfig.json` because eslint was complaining about test files missing a project. But doing so made the `tsc` command include both `lib` and `test` directories under `/dist` when building the plugin; while before the config of `lib` was inlined directly under `/dist`.

The config has been mostly copied from https://github.com/snyk/snyk-gradle-plugin/blob/3ee9402f50ba90d9a767b112993d77e5412388a3/.eslintrc.json

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2746

#### Screenshots


#### Additional questions
