### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,14 +140,14 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - run: sudo npm i -g semantic-release@22 @semantic-release/exec pkg
       - install_deps
       - run:
-          name: Publish to GitHub
-          command: npx semantic-release
+          name: Publish to NPM and GitHub via OIDC Trusted Publishing
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@25.0.5
 
 workflows:
-  version: 2
   test_and_release:
     jobs:
     - prodsec/secrets-scan:
@@ -203,8 +203,10 @@ workflows:
     # Release
     - release:
         name: Release
-        context: nodejs-app-release
-        node_version: "20.18"
+        context:
+          - nodejs-install
+          - github-release
+        node_version: "22.18"
         filters:
           branches:
             only:

--- a/package.json
+++ b/package.json
@@ -18,10 +18,16 @@
     "dist",
     "LICENSE"
   ],
-  "homepage": "https://github.com/snyk/snyk-php-plugin",
+  "homepage": "https://github.com/snyk/snyk-php-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/snyk/snyk-php-plugin/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/snyk/snyk-php-plugin"
+    "url": "https://github.com/snyk/snyk-php-plugin.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "author": "Snyk <https://snyk.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by Snyk internal team

### What this does

Set up NPM OIDC Trusted Publishing for the package


### Notes for the reviewer
- This package is still used by Snyk products. The repo and the npm package are both public and they will remain this way. 
- Trusted Publishing from CircleCI has been configured. 
- The release group was granted Write access to the repo.


### More information

- [Jira ticket CMPA-552](https://snyksec.atlassian.net/browse/CMPA-552)